### PR TITLE
feat(cloud): add support for calibration

### DIFF
--- a/growbe-cloud/package-lock.json
+++ b/growbe-cloud/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@berlingoqc/lb-extensions": "^1.1.1",
         "@berlingoqc/sso": "^1.1.1",
-        "@growbe2/growbe-pb": "^1.1.5-SNAPSHOT-6",
+        "@growbe2/growbe-pb": "^1.1.5-SNAPSHOT-8",
         "@loopback/boot": "^3.4.2",
         "@loopback/core": "^2.16.2",
         "@loopback/repository": "^3.7.1",
@@ -729,9 +729,9 @@
       "dev": true
     },
     "node_modules/@growbe2/growbe-pb": {
-      "version": "1.1.5-SNAPSHOT-6",
-      "resolved": "https://npm.pkg.github.com/download/@growbe2/growbe-pb/1.1.5-SNAPSHOT-6/e8e50e80aea19e0f9612dbac35bbac3723c1d9373dbac819c9093fc7ad50fb3d",
-      "integrity": "sha512-qlWk10nBGup+GMrIP66wn9ZPRCBT1YK3QZmdSsXdI70ztyaT1TCr5lvfldy7/jzS3Dynts1kDfRZHNtaG5qt4g==",
+      "version": "1.1.5-SNAPSHOT-8",
+      "resolved": "https://npm.pkg.github.com/download/@growbe2/growbe-pb/1.1.5-SNAPSHOT-8/5aef9e6f57511acfa5cbde2558779006702d4f09f5d7f3f73f761c5e21c4e57a",
+      "integrity": "sha512-PLmlrKkdolB8ugxsx5wgfthzA3OTnu3leVx/DsnYI7z6tRaGCBX109YKXueTrbdC4vYGJGmdAEskxbCPUOmfJg==",
       "license": "MIT",
       "dependencies": {
         "protobuf-typescript": "6.8.8",
@@ -9077,9 +9077,9 @@
       "dev": true
     },
     "@growbe2/growbe-pb": {
-      "version": "1.1.5-SNAPSHOT-6",
-      "resolved": "https://npm.pkg.github.com/download/@growbe2/growbe-pb/1.1.5-SNAPSHOT-6/e8e50e80aea19e0f9612dbac35bbac3723c1d9373dbac819c9093fc7ad50fb3d",
-      "integrity": "sha512-qlWk10nBGup+GMrIP66wn9ZPRCBT1YK3QZmdSsXdI70ztyaT1TCr5lvfldy7/jzS3Dynts1kDfRZHNtaG5qt4g==",
+      "version": "1.1.5-SNAPSHOT-8",
+      "resolved": "https://npm.pkg.github.com/download/@growbe2/growbe-pb/1.1.5-SNAPSHOT-8/5aef9e6f57511acfa5cbde2558779006702d4f09f5d7f3f73f761c5e21c4e57a",
+      "integrity": "sha512-PLmlrKkdolB8ugxsx5wgfthzA3OTnu3leVx/DsnYI7z6tRaGCBX109YKXueTrbdC4vYGJGmdAEskxbCPUOmfJg==",
       "requires": {
         "protobuf-typescript": "6.8.8",
         "protobufjs": "6.10.2"

--- a/growbe-cloud/package.json
+++ b/growbe-cloud/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@berlingoqc/lb-extensions": "^1.1.1",
     "@berlingoqc/sso": "^1.1.1",
-    "@growbe2/growbe-pb": "^1.1.5-SNAPSHOT-6",
+    "@growbe2/growbe-pb": "^1.1.5-SNAPSHOT-8",
     "@loopback/boot": "^3.4.2",
     "@loopback/core": "^2.16.2",
     "@loopback/repository": "^3.7.1",

--- a/growbe-cloud/src/cloud/cloud.component.ts
+++ b/growbe-cloud/src/cloud/cloud.component.ts
@@ -18,6 +18,7 @@ import {
   GrowbeModuleGraphController,
   UserPreferenceController,
   GrowbeMainboardVersionController,
+  GrowbeModuleCalibrationController,
 } from './controllers';
 import {CRUD_CONTROLLERS} from './crud-controller';
 
@@ -56,7 +57,8 @@ export class CloudComponent implements Component {
     GrowbeModuleGraphController,
     GrowbeMainboardVersionController,
     GrowbeModuleController,
-    UserPreferenceController
+    UserPreferenceController,
+    GrowbeModuleCalibrationController,
   ];
   bindings = [
     Binding.bind(GrowbeMainboardBindings.WATCHERS).to(watchers)

--- a/growbe-cloud/src/cloud/controllers/growbe-module-calibration.controller.ts
+++ b/growbe-cloud/src/cloud/controllers/growbe-module-calibration.controller.ts
@@ -1,0 +1,74 @@
+import { SOILCalibrationStart, SOILCalibrationStep } from "@growbe2/growbe-pb";
+import { service } from "@loopback/core";
+import { param, patch, requestBody } from "@loopback/rest";
+import { GrowbeCalibrationService } from "../../services/growbe-calibration.service";
+import { authorizeGrowbe } from "../authorization";
+
+
+
+export class GrowbeModuleCalibrationController {
+  constructor(
+    @service(GrowbeCalibrationService)
+    private calibrationService: GrowbeCalibrationService,
+  ) {}
+
+
+  @patch("/growbe/{id}/modules/{moduleid}/calibration/start")
+  @authorizeGrowbe({
+    growbeIdIndex: 0
+  })
+  startCalibration(
+      @param.path.string("id") id: string,
+      @param.path.string("moduleid") moduleId: string,
+      @requestBody() body: SOILCalibrationStart,
+  ) {
+      return this.calibrationService.startCalibration(id, moduleId, body);
+  }
+
+  @patch("/growbe/{id}/modules/{moduleid}/calibration/set")
+  @authorizeGrowbe({
+    growbeIdIndex: 0
+  })
+  setCalibration(
+      @param.path.string("id") id: string,
+      @param.path.string("moduleid") moduleId: string,
+      @requestBody() body: SOILCalibrationStep,
+  ) {
+      return this.calibrationService.setStepCalibration(id, moduleId, body);
+  }
+
+  @patch("/growbe/{id}/modules/{moduleid}/calibration/confirm")
+  @authorizeGrowbe({
+    growbeIdIndex: 0
+  })
+  confirmCalibration(
+      @param.path.string("id") id: string,
+      @param.path.string("moduleid") moduleId: string,
+  ) {
+      return this.calibrationService.confirmCalibration(id, moduleId);
+  }
+
+  @patch("/growbe/{id}/modules/{moduleid}/calibration/cancel")
+  @authorizeGrowbe({
+    growbeIdIndex: 0
+  })
+  cancelCalibration(
+      @param.path.string("id") id: string,
+      @param.path.string("moduleid") moduleId: string,
+  ) {
+      return this.calibrationService.cancelCalibration(id, moduleId);
+  }
+
+  @patch("/growbe/{id}/modules/{moduleid}/calibration/status")
+  @authorizeGrowbe({
+    growbeIdIndex: 0
+  })
+  statusCalibration(
+      @param.path.string("id") id: string,
+      @param.path.string("moduleid") moduleId: string,
+      @requestBody() body: SOILCalibrationStep,
+  ) {
+      return this.calibrationService.statusCalibration(id, moduleId);
+  }
+
+}

--- a/growbe-cloud/src/cloud/controllers/index.ts
+++ b/growbe-cloud/src/cloud/controllers/index.ts
@@ -4,3 +4,4 @@ export * from './growbe-module-graph.controller';
 export * from './growbe-mainboard-version.controller';
 export * from './growbe-module.controllers';
 export * from './user-preference.controller';
+export * from './growbe-module-calibration.controller';

--- a/growbe-cloud/src/services/growbe-calibration.service.ts
+++ b/growbe-cloud/src/services/growbe-calibration.service.ts
@@ -1,0 +1,103 @@
+import { ActionCode, SOILCalibrationStart, SOILCalibrationStep, SOILCalibrationStepEvent } from "@growbe2/growbe-pb";
+import { BindingScope, injectable, service } from "@loopback/core";
+import { getTopic, GrowbeLogsService, MQTTService } from ".";
+
+@injectable({scope: BindingScope.TRANSIENT})
+export class GrowbeCalibrationService {
+	constructor(
+		@service(MQTTService)
+		public mqttService: MQTTService,
+		@service(GrowbeLogsService)
+		private growbeLogsService: GrowbeLogsService,
+	) {}
+
+
+    // FOR THE WATCHER
+
+    async onCalibrationEvent(
+        mainboardId: string,
+        moduleId: string,
+        event: SOILCalibrationStepEvent, 
+    ) {
+        return this.mqttService.send(
+            getTopic(mainboardId, `/cloud/m/${moduleId}/calibrationEvent`),
+            JSON.stringify(event)
+        );
+    }
+
+
+    // FOR THE CLOUD
+
+    async startCalibration(
+        mainboardId: string,
+        moduleId: string,
+        event: SOILCalibrationStart, 
+    ) {
+        return this.mqttService
+            .sendWithResponse(
+                mainboardId,
+                getTopic(mainboardId, `/board/startCalibration/${moduleId}`),
+                "{}",
+                { waitingTime: 6000, responseCode: ActionCode.SYNC_REQUEST}
+            ).toPromise();
+    }
+
+    async setStepCalibration(
+        mainboardId: string,
+        moduleId: string,
+        event: SOILCalibrationStep, 
+    ) {
+        const payload = SOILCalibrationStep.encode(event).finish();
+        return this.mqttService
+            .sendWithResponse(
+                mainboardId,
+                getTopic(mainboardId, `/board/setCalibration/${moduleId}`),
+                payload,
+                { waitingTime: 6000, responseCode: ActionCode.SYNC_REQUEST}
+            ).toPromise();
+    }
+
+    async statusCalibration(
+        mainboardId: string,
+        moduleId: string,
+    ) {
+        return this.mqttService
+            .sendWithResponse(
+                mainboardId,
+                getTopic(mainboardId, `/board/statusCalibration/${moduleId}`),
+                "{}",
+                { waitingTime: 6000, responseCode: ActionCode.SYNC_REQUEST}
+            ).toPromise();
+    }
+
+    async confirmCalibration(
+        mainboardId: string,
+        moduleId: string,
+    ) {
+        return this.mqttService
+            .sendWithResponse(
+                mainboardId,
+                getTopic(mainboardId, `/board/terminateCalibration/${moduleId}`),
+                "{}",
+                { waitingTime: 6000, responseCode: ActionCode.SYNC_REQUEST}
+            ).toPromise(); 
+    }
+
+    async cancelCalibration(
+        mainboardId: string,
+        moduleId: string,
+    ) {
+        return this.mqttService
+            .sendWithResponse(
+                mainboardId,
+                getTopic(mainboardId, `/board/cancelCalibration/${moduleId}`),
+                "{}",
+                { waitingTime: 6000, responseCode: ActionCode.SYNC_REQUEST}
+            ).toPromise(); 
+    }
+
+
+
+
+
+}

--- a/growbe-cloud/src/services/mqtt-listener.service.ts
+++ b/growbe-cloud/src/services/mqtt-listener.service.ts
@@ -32,7 +32,6 @@ export class MqttListnener {
     addWatcher(subject: DataSubject): Subscription {
         return this.mqttService.observable
           .pipe(
-            tap((x) => console.log(x)),
             filter(
               x =>
                 !x.topic.includes('cloud') &&
@@ -41,7 +40,6 @@ export class MqttListnener {
         ).subscribe((data) => {
           (async () => {
             try {
-              console.log(data);
               const d = subject.model
                 ? subject.model.decode(data.message)
                 : data.message;

--- a/growbe-cloud/src/services/mqtt.service.ts
+++ b/growbe-cloud/src/services/mqtt.service.ts
@@ -25,6 +25,7 @@ export class MQTTService {
 
   async connect() {
     this.client = await mqtt.connectAsync(this.url);
+    this.client.setMaxListeners(100);
     this.observable = new Observable(sub => {
       this.client.on('message', (topic, message) => {
         sub.next({topic, message});

--- a/growbe-cloud/src/watcher/watcher.component.ts
+++ b/growbe-cloud/src/watcher/watcher.component.ts
@@ -1,9 +1,10 @@
-import {ActionResponse, FieldAlarmEvent, HearthBeath, HelloWord, LocalConnection, ModuleData, UpdateExecute } from '@growbe2/growbe-pb';
+import {ActionResponse, FieldAlarmEvent, HearthBeath, HelloWord, LocalConnection, ModuleData, UpdateExecute, SOILCalibrationStepEvent } from '@growbe2/growbe-pb';
 import {Binding, Component} from '@loopback/core';
 import {GrowbeMainboardBindings} from '../keys';
 import { GroupEnum, LogTypeEnum, SeverityEnum } from '../models';
 import { DataSubject, funcModuleSubject } from '../observers/data-subject.model';
 import {GrowbeActionReponseService, GrowbeHardwareAlarmService, GrowbeLogsService, GrowbeModuleService, GrowbeService, GrowbeStateService} from '../services';
+import { GrowbeCalibrationService } from '../services/growbe-calibration.service';
 import {
   GrowbeStateWatcherObserver,
 } from './observers';
@@ -93,6 +94,22 @@ const watchers: DataSubject[] = [
     model: null,
     regexTopic: 'restarted',
     service: GrowbeLogsService,
+  },
+  {
+    func: funcModuleSubject((id, moduleId, service: GrowbeCalibrationService, data: SOILCalibrationStepEvent) => {
+      return service.onCalibrationEvent(id, moduleId, data)
+    }),
+    model: SOILCalibrationStepEvent,
+    regexTopic: 'calibrationEvent',
+    service: GrowbeCalibrationService,
+  },
+  {
+    func: funcModuleSubject((id, moduleId, service: GrowbeModuleService, data: any) => {
+      return service.receivedConfigFromMainboard(moduleId, data);
+    }),
+    model: null,
+    regexTopic: 'config_updated',
+    service: GrowbeModuleService,
   }
 ];
 

--- a/proto/module.proto
+++ b/proto/module.proto
@@ -53,6 +53,64 @@ message SOILModuleData {
    int32 timestamp = 9;
 }
 
+message SOILProbeConfig {
+    int32 low = 1;
+    int32 high = 2;
+}
+
+message SOILModuleConfig {
+    SOILProbeConfig p0 = 1;
+    SOILProbeConfig p1 = 2;
+    SOILProbeConfig p2 = 3;
+    SOILProbeConfig p3 = 4;
+    SOILProbeConfig p4 = 5;
+    SOILProbeConfig p5 = 6;
+    SOILProbeConfig p6 = 7;
+    SOILProbeConfig p7 = 8;
+}
+
+
+enum CalibrationStep {
+    READY_CALIBRATION = 0;
+    LOW_CALIBRATION = 1;
+    HIGH_CALIBRATION = 2;
+    ERROR_CALIBRATION = 3;
+    WAITING_CONFIRMATION_CALIBRATION = 4;
+}
+
+enum CalibrationStepStatus {
+    INSUFFISANT_DATA_STATUS = 0;
+    ENOUGHT_DATA_STATUS = 1;
+    ERROR_STATUS = 2;
+    AWAITING_STEP_STATUS = 3;
+}
+
+enum CalibrationError {
+    NONE_ERROR = 0;
+    ALREADY_STARTED_ERROR = 1;
+    INSTABLE_DATA_ERROR = 2;
+    NOT_ENOUGHT_DATA_ERROR = 3;
+}
+
+// Message to start the calibration request
+message SOILCalibrationStart {}
+
+// Message to configure the current step of the request
+message SOILCalibrationStep {
+    CalibrationStep requested_step = 1;
+}
+
+// Event produce by the process for the cloud to display information to the user
+message SOILCalibrationStepEvent {
+    CalibrationStep step = 1;
+    CalibrationStepStatus status = 2;
+    CalibrationError erro = 3;
+    string messag = 4;
+
+    repeated SOILModuleData low = 5;
+    repeated SOILModuleData high = 6;
+}
+
 message WAModuleData {
     int32 PH = 2;
     int32 EC = 3;

--- a/proto/package.json
+++ b/proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growbe2/growbe-pb",
-  "version": "1.1.5-SNAPSHOT-6",
+  "version": "1.1.5-SNAPSHOT-8",
   "description": "Libraire avec les définitions protobuf",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add support for calibration of soil module by MQTT, does not store anything.

* Add MQTT message to receive a module config from the mainboard and save it in the cloud and publish it to MQTT